### PR TITLE
Added a email_subject function to Sale. #5996

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -46,6 +46,14 @@ class Sale:
         """
         return unicode(uuid4())
 
+    def email_subject(self, purpose=None):
+        """
+        Set the subject of the email to be sent.
+        """
+        # Generic message.
+        if purpose == "confirm":
+            return "New order has been placed"
+
     @classmethod
     @route('/orders')
     @route('/orders/<int:page>')
@@ -142,7 +150,10 @@ class Sale:
 
         if to_emails:
             # Send the order confirmation notification email
-            subject = "New order has been placed: #%s" % self.reference
+            subject = (
+                self.email_subject(purpose="confirm") + 
+                ": #%s" % self.reference
+            )
             email_message = render_email(
                 CONFIG['smtp_from'], to_emails, subject,
                 text_template='emails/sale-confirmation-text.jinja',


### PR DESCRIPTION
We have the following options for implementing the flexibility to change email subject in downstream modules -:
1. We could add the subject as a field in Sale Configuration. The Tryton user then sets the subject from the client.
2. We could add a method for generating the email subject, initially having only a generic subject message, which can be overriden in downstream modules. It will take as argument a `purpose`.

This PR implements option 2.
