### PR TITLE
Added methods to generate json-ld for email markup #6758

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,13 +3,13 @@
 
     nereid_checkout
 
-    :copyright: (c) 2010-2013 by Openlabs Technologies & Consulting (P) Ltd.
+    :copyright: (c) 2010-2015 by Openlabs Technologies & Consulting (P) Ltd.
     :license: GPLv3, see LICENSE for more details
 
 '''
 from trytond.pool import Pool
 
-from sale import Sale
+from sale import Sale, SaleLine
 from payment import Website, NereidPaymentMethod
 from checkout import Cart, Checkout, Party, Address
 
@@ -23,5 +23,6 @@ def register():
         Checkout,
         NereidPaymentMethod,
         Address,
+        SaleLine,
         type_="model", module="nereid_checkout"
     )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,7 @@ import unittest
 import trytond.tests.test_tryton
 from test_checkout import TestCheckoutSignIn, TestCheckoutShippingAddress, \
     TestCheckoutDeliveryMethod, TestCheckoutBillingAddress, \
-    TestCheckoutPayment
+    TestCheckoutPayment, TestSale
 from test_address import TestAddress
 
 
@@ -28,6 +28,7 @@ def suite():
         loader.loadTestsFromTestCase(TestCheckoutBillingAddress),
         loader.loadTestsFromTestCase(TestCheckoutPayment),
         loader.loadTestsFromTestCase(TestAddress),
+        loader.loadTestsFromTestCase(TestSale)
     ])
     return test_suite
 


### PR DESCRIPTION
These methods will be used to generate json-ld for a sale
record to send to Google, so that users can get a
View Order email markup when they receive order confirmation
emails on their Gmail account